### PR TITLE
DOC: add BSD 3-clause license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2025-2026 Los Alamos National Laboratory.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
* Related to one of the checklist items mentioned in gh-1.

* Add a BSD 3-clause license, matching what `scikit-learn` does at: https://github.com/scikit-learn/scikit-learn/blob/main/COPYING (much of the rest of the scientific Python ecosystem is also BSD 3, so makes sense I think...)

* Our approach is the same as theirs, except that we change the copyright holder to LANL.

TODO:

- [ ] we should very carefully check what we `import`, to make sure that we can in fact claim a BSD 3-clause license (we can't import anything copyleft/GPL, for example; the `grafo..` in the testsuite is kind of annoying, but not a true runtime dependency--I may actually try to get rid of that just to make life easier anyway)
- [ ] need to figure out what LANL FCI currently has on record for our assigned license, and if it isn't BSD-3 we'll need a bit of back and forth with them to get the records updated
- [ ] after this gets merged, make sure the license information is correctly displayed on our GitHub landing page as described at: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository