### PR TITLE
MAINT: module top cleanups

### DIFF
--- a/src/rvfl/__init__.py
+++ b/src/rvfl/__init__.py
@@ -1,4 +1,3 @@
-# rvfl/__init__.py
 from .model import RVFL
 
 __all__ = ["RVFL"]

--- a/src/rvfl/activations.py
+++ b/src/rvfl/activations.py
@@ -1,4 +1,3 @@
-# rvfl/activations.py
 import numpy as np
 import scipy
 

--- a/src/rvfl/model.py
+++ b/src/rvfl/model.py
@@ -1,4 +1,3 @@
-# rvfl/model.py
 import numpy as np
 from scipy.special import logsumexp
 from scipy.stats import mode

--- a/src/rvfl/tests/__init__.py
+++ b/src/rvfl/tests/__init__.py
@@ -1,1 +1,0 @@
-# tests/__init__.py

--- a/src/rvfl/tests/test_model.py
+++ b/src/rvfl/tests/test_model.py
@@ -1,5 +1,3 @@
-# tests/test_model.py
-
 import graforvfl
 import numpy as np
 import pytest

--- a/src/rvfl/tests/test_regression.py
+++ b/src/rvfl/tests/test_regression.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pytest
 from graforvfl import RvflRegressor

--- a/src/rvfl/weights.py
+++ b/src/rvfl/weights.py
@@ -1,4 +1,3 @@
-# rvfl/weights.py
 import numpy as np
 
 


### PR DESCRIPTION
* Cleanup the top of our library module files--generally, this means removing the extraneous comments at the tops of files that contain the file name/path. This is obviously a minor point, but it does add extra maintenance burden we don't need moving forward as the project name/structure may change and we don't want to have to remember to keep changing these comments.

* Some of this slipped through as noted at https://github.com/lanl/ascr_rvfl/pull/65#issuecomment-3764454861 -- let's try to address minor comments before merging moving forward to reduce the need for these cleanups.