### PR TITLE
CI: test wheels on Windows

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m build
     - name: install and test wheel
+      shell: bash
       run: |
         python -m pip install dist/gfdl*.whl
         # test deps need to be manually installed


### PR DESCRIPTION
* Start testing wheel builds on Windows platform in the CI. This is perhaps overkill, but our testing is fast enough for now that we can probably handle it. I don't anticipate any complications for now since our code is still "pure Python."