### PR TITLE
MAINT, REL: set version to `0.1.0.dev0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gfdl"
-version = "0.0.0"
+version = "0.1.0.dev0"
 description = "Gradient Free Deep Learning (GFDL) networks including single and multi layer random vector functional link (RVFL) networks and extreme learning machines (ELMs)"
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
* Ahead of the upcoming `0.1.0` release, set our version number properly to `0.1.0.dev0`. The `.dev0` will be stripped when the release manager finalizes the release/tag.

* For reference examples in upstream projects see:
  - https://github.com/scipy/scipy/blob/main/pyproject.toml#L36     
  - https://github.com/numpy/numpy/blob/main/pyproject.toml#L10