### PR TITLE
ENH: control rtol for regressor

### DIFF
--- a/src/gfdl/model.py
+++ b/src/gfdl/model.py
@@ -732,7 +732,7 @@ class GFDLRegressor(RegressorMixin, MultiOutputMixin, GFDL):
 
     rtol : float, default=None
         Cutoff for small singular values for the Moore-Penrose
-        pseudo-inverse. Only applies when ``direct_links=True``.
+        pseudo-inverse. Only applies when ``reg_alpha=None``.
         When ``rtol=None``, the array API standard default for
         ``pinv`` is used.
 

--- a/src/gfdl/tests/test_regression.py
+++ b/src/gfdl/tests/test_regression.py
@@ -94,7 +94,7 @@ def test_sklearn_api_conformance(estimator, check):
 @pytest.mark.parametrize("reg_alpha, expected", [
     (0.1, 0.78550376),
     # NOTE: for Moore-Penrose, a large singular value
-    # cutoff (rcond) is required to achieve reasonable R2 with
+    # cutoff (rtol) is required to achieve reasonable R2 with
     # the Boston Housing dataset
     (None, 0.73452466),
 ])


### PR DESCRIPTION
* Deals with the `GFDLRegressor` part of gh-12. We need to allow the end user to modulate the singular value cutoff for any estimator that uses the Moore-Penrose pseudo-inverse because ill-conditioned or rank-deficient matrices cannot otherwise be handled correctly. It is the same reason that `np.pinv` itself offers the ``rtol`` parameter.

* The new Boston Housing regression test case added here cannot possibly be passed on the `main` branch because the user cannot control ``rtol`` and the matrix is otherwise too pathological to invert with the default ``rtol``.

* Note that this ``rtol`` argument requires at least NumPy `2.0.0`. Please help with gh-38 in that regard.