### PR TITLE
CI, DOC: lint `weights.py` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         ruff check
     - name: lint and build docs
       run: |
-        numpydoc lint src/gfdl/model.py src/gfdl/activations.py 
+        numpydoc lint src/gfdl/model.py src/gfdl/activations.py src/gfdl/weights.py
         cd docs && make html SPHINXOPTS="-W --keep-going"
     - name: test
       run: |


### PR DESCRIPTION
* Fixes gh-26.

* As noted in the matching issue, `weights.py` was not being linted by `numpydoc` in our CI. It seems that this module passes the docs linting locally, so let's see if we can turn it on in the CI now.

* Eventually we'll probably want to avoid needing to list every single module we want to lint with `numpydoc`, but for now maybe this suffices.