### PR TITLE
DOC, MAINT: repo source to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ classifiers = [
 dependencies = ["numpy>=2.0.0",
                 "scikit-learn>=1.2.1"]
 
+[project.urls]
+source = "https://github.com/lanl/GFDL"
+download = "https://github.com/lanl/GFDL/releases"
+tracker = "https://github.com/lanl/GFDL/issues"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
* Fixes gh-43.

* Adds the `project.urls` section to our `pyproject.toml` file so that when we do a PyPI release, the PyPI release page will link back to our open repository on GitHub, similar to the screenshot in the matching issue.