### PR TITLE
DOC: Update branch name for source linking 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ import os
 from pathlib import Path
 
 GITHUB_REPO_URL = "https://github.com/lanl/GFDL"   
-GITHUB_REF = "treddy_conform_with_numpydoc" 
+GITHUB_REF = "main" 
 
 # conf.py is docs/source/conf.py -> repo root is usually parents[2]
 REPO_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
Addresses issue gh-34 
Previously, I was using the specific branch for testing out if the links under "source" beside an estimator api that directs to the actual code. Now, it points to main. 