### PR TITLE
CI: run on maintenance branches as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: Base CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - maintenance/**
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - maintenance/**
 
 jobs:
   test:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -2,9 +2,12 @@ name: Wheel Test
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - maintenance/**
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - maintenance/**
 
 jobs:
   test:


### PR DESCRIPTION
* There is no matching issue for this patch, but I think it would be helpful if we allow CI to run on maintenance branches so that we can check that i.e., backported bug fixes are "ok" on release branches as well.

* Also, there is no need to run the CI again on `main` after merging a PR--it should suffice to check that CI is passing before the merge (GHA will automatically try merging the branch into `main` before the tests run in the PR, so basically just wastes electricity). The reason for running CI on pushes to release/maintenance branches is that sometimes projects will setup for automatic wheel builds on merge to release branches (we don't have that yet, but doesn't hurt to have it on I don't think, merges to release branches will be rare anyway).

* This configuration is lifted directly from upstream at: https://github.com/scipy/scipy/blob/main/.github/workflows/linux.yml#L3 where it has been working well for years.