### PR TITLE
MAINT: runtime min version enforcement

### DIFF
--- a/.github/constraints/deps.txt
+++ b/.github/constraints/deps.txt
@@ -1,6 +1,7 @@
-numpy
-scipy>=1.7.1
-scikit-learn>=1.2.1
+numpy>=2.0.0
+scipy>=1.13.0
+scikit-learn>=1.5.0
+packaging>=24.0
 matplotlib>=3.7.5
 numpydoc
 sphinx_copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ classifiers = [
     "Operating System :: MacOS",
 ]
 dependencies = ["numpy>=2.0.0",
-                "scikit-learn>=1.2.1"]
+                "scikit-learn>=1.5.0",
+                "scipy>=1.13.0",
+                "packaging>=24.0"]
 
 [project.urls]
 source = "https://github.com/lanl/GFDL"

--- a/src/gfdl/__init__.py
+++ b/src/gfdl/__init__.py
@@ -1,3 +1,36 @@
+import platform
+
+import numpy as np
+import packaging
+import scipy
+import sklearn
+from packaging.version import Version
+
 from .model import GFDL
 
 __all__ = ["GFDL"]
+
+packaging_version = Version(packaging.__version__)
+min_packaging_version = "24.0"
+if packaging_version < Version(min_packaging_version):
+    raise ImportError(f"{packaging_version=}, but {min_packaging_version=}")
+
+python_version = Version(platform.python_version())
+min_python_version = "3.12"
+if python_version < Version(min_python_version):
+    raise ImportError(f"{python_version=}, but {min_python_version=}")
+
+numpy_version = Version(np.__version__)
+min_numpy_version = "2.0.0"
+if numpy_version < Version(min_numpy_version):
+    raise ImportError(f"{numpy_version=}, but {min_numpy_version=}")
+
+sklearn_version = Version(sklearn.__version__)
+min_sklearn_version = "1.5.0"
+if sklearn_version < Version(min_sklearn_version):
+    raise ImportError(f"{sklearn_version=}, but {min_sklearn_version=}")
+
+scipy_version = Version(scipy.__version__)
+min_scipy_version = "1.13.0"
+if scipy_version < Version(min_scipy_version):
+    raise ImportError(f"{scipy_version=}, but {min_scipy_version=}")


### PR DESCRIPTION
* Fixes gh-38.

* Enforce runtime version checks for dependencies to prevent folks from running the code with unsupported/untested versions of the dependencies. The version checks happen via the PEP440-compliant `packaging` library, and follow the SPEC 0 support windows suggested by the community at:
https://scientific-python.org/specs/spec-0000/

* For those dependencies that are not mentioned explicitly in SPEC 0, I've set their minimum version bound to a release from ~2 years ago. I did not set/adjust version bounds for
documentation/testing/linting-related dependencies for now (a bit less critical in the short term).

* Maximum version bounds may make sense to set on maintenance branches, but don't usually get set on the `main` branch.