### PR TITLE
REL: set version to 0.2.0

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,5 +49,5 @@ Quick example
    :maxdepth: 2
 
    api/index
+   release
    dev
-   release 

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -7,4 +7,5 @@ This is the list of changes to GFDL between each release.
 .. toctree::
    :maxdepth: 1
 
+   release/0.2.0-notes
    release/0.1.0-notes

--- a/docs/source/release/0.2.0-notes.rst
+++ b/docs/source/release/0.2.0-notes.rst
@@ -1,0 +1,59 @@
+==========================
+GFDL 0.2.0 Release Notes
+==========================
+
+.. note:: GFDL 0.2.0 is not released yet!
+
+.. contents::
+
+Gradient free deep learning (GFDL) 0.2.0 is the culmination of X
+months of hard work. Our development attention will now shift to
+bug-fix releases on the 0.2.x branch, and on adding new features
+on the main branch.
+
+This release requires Python 3.12-3.14.
+
+
+**************************
+Highlights of this release
+**************************
+
+
+
+************
+New features
+************
+
+
+``gfdl.model`` improvements
+============================
+
+*******************
+Deprecated features
+*******************
+
+******************************
+Backwards incompatible changes
+******************************
+
+*************
+Other changes
+*************
+
+
+*******
+Authors
+*******
+
+
+
+************************
+Issues closed for 0.2.0
+************************
+
+
+************************
+Pull requests for 0.2.0
+************************
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gfdl"
-version = "0.1.0.dev0"
+version = "0.2.0.dev0"
 description = "Gradient Free Deep Learning (GFDL) networks including single and multi layer random vector functional link (RVFL) networks and extreme learning machines (ELMs)"
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
* Don't merge until the `0.1.0` release notes updates have been merged and the `maintenance/0.1.x` branch has been pushed up (I'll probably self-merge this when the time is right).

* This will be slightly more complex than usual because it follows our first-ever release (i.e., the release notes infrastructure itself hasn't even been merged, so this will require merge conflict resolution when the time comes...).