### PR TITLE
MAINT: EnsembleGFDL--inherit from base

### DIFF
--- a/src/gfdl/model.py
+++ b/src/gfdl/model.py
@@ -345,7 +345,7 @@ class GFDLClassifier(ClassifierMixin, GFDL):
         return out
 
 
-class EnsembleGFDL(GFDL):
+class EnsembleGFDL(BaseEstimator):
     """Base class for ensemble GFDL model for classification and regression."""
     def __init__(
         self,
@@ -356,13 +356,15 @@ class EnsembleGFDL(GFDL):
         reg_alpha: float = None,
         rtol: float | None = None,
     ):
-        super().__init__(hidden_layer_sizes=hidden_layer_sizes,
-                         activation=activation,
-                         weight_scheme=weight_scheme,
-                         direct_links=True,
-                         seed=seed,
-                         reg_alpha=reg_alpha,
-                         rtol=rtol)
+        self.hidden_layer_sizes = hidden_layer_sizes
+        self.activation = activation
+        self.weight_scheme = weight_scheme
+        self.seed = seed
+        self.reg_alpha = reg_alpha
+        self.rtol = rtol
+
+    def get_generator(self, seed):
+        return np.random.default_rng(seed)
 
     def fit(self, X, Y):
 


### PR DESCRIPTION
* This supersedes https://github.com/lanl/ascr_rvfl/pull/67 in the private repo, since this is clearly library code related and so should be dealt with in our open library code repo.

* I believe the original motivation was to simplify the inheritance chain for `EnsembleGFDL`, since it now can inherit directly from an `sklearn` base class, which I suppose is a slight simplification.

* I made Emma a co-author on the commit, since this is just an updated version of her work.