### PR TITLE
MAINT, CI: bump ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -v ".[test]"
-        python -m pip install ruff==0.13.1
+        python -m pip install ruff==0.15.0
         python -m pip install -r .github/constraints/deps.txt
     - name: lint
       run: |


### PR DESCRIPTION
* Use the latest version of `ruff` for linting in the CI.

* Perhaps we should consider using `dependabot` for this simple stuff:
https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart-guide