### PR TITLE
DOC, MAINT: description for PyPI page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "gfdl"
 version = "0.2.0.dev0"
 description = "Gradient Free Deep Learning (GFDL) networks including single and multi layer random vector functional link (RVFL) networks and extreme learning machines (ELMs)"
 requires-python = ">=3.12"
+readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
* Fixes gh-59.

* As noted in the matching issue, the project description is completely missing on our PyPI landing page, which isn't very professional. This small patch connects our `README.md` to fill in the content there. Other projects like `scikit-learn` also fill that PyPI content in from their `README`.

* Our `README` could use some improvement, but that's a separate matter, and this will allow it to get pulled in to the PyPI landing page automatically moving forward.

If you'd like to see how this looks, I did a sandbox deployment of this feature branch to the test instance of PyPI here: https://test.pypi.org/project/gfdl/0.2.0.dev0/. For reference, this was done using this incantation: `twine upload --repository testpypi dist/*`.

The "Project description" should be showing up there (it won't show up on "regular" PyPI until we do a `0.2.0` release of course).