### PR TITLE
DOC, MAINT: add PyPI doc link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = ["numpy>=2.0.0",
 source = "https://github.com/lanl/GFDL"
 download = "https://github.com/lanl/GFDL/releases"
 tracker = "https://github.com/lanl/GFDL/issues"
+documentation = "https://lanl.github.io/GFDL/"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
* Fixes gh-65.

* Add a link back to our deployed `main` branch documentation from our `pyproject.toml` file, so that users may easily access the documentation from our PyPI release landing page.

I tested this by doing a temporary sandbox release on this branch, which you can inspect at https://test.pypi.org/project/gfdl/0.2.0.dev1/.

If you click through there you should see a new documentation link like below. This won't show up on our regular PyPI page until the `0.2.0` release though.

<img width="290" height="270" alt="image" src="https://github.com/user-attachments/assets/cefd02d0-883f-473f-a8ee-1b90fc7157d3" />
 