### PR TITLE
MAINT, CI: draft dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "MAINT"
+    labels:
+      - "maintenance"
+  - package-ecosystem: pip
+    directory: .github/constraints
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "MAINT"
+    labels:
+      - "maintenance"


### PR DESCRIPTION
* Fixes gh-62.

* Add an initial `dependabot` configuration to our project, to help keep dependencies up to date with less human intervention.

* To get this rolling, I copied and modified the `dependabot` config that NumPy uses at:
https://github.com/numpy/numpy/blob/main/.github/dependabot.yml

* I did not use AI/LLMs during the preparation of this patch.