### PR TITLE
MAINT: errors for widths <= 0

### DIFF
--- a/src/gfdl/model.py
+++ b/src/gfdl/model.py
@@ -47,10 +47,13 @@ class GFDL(BaseEstimator):
         # Y shape: (n_samples, n_classes-1)
         if self.reg_alpha is not None and self.reg_alpha < 0.0:
             raise ValueError("Negative reg_alpha. Expected range : None or [0.0, inf).")
+        hidden_layer_sizes = np.asarray(self.hidden_layer_sizes)
+        if hidden_layer_sizes.min() < 1:
+            raise ValueError("hidden_layer_sizes must be > 0, "
+                             f"got {hidden_layer_sizes}")
         fn = resolve_activation(self.activation)[1]
         self._activation_fn = fn
         self._N = X.shape[1]
-        hidden_layer_sizes = np.asarray(self.hidden_layer_sizes)
         self._weight_mode = resolve_weight(self.weight_scheme)
 
         # weights shape: (n_layers,)
@@ -371,10 +374,13 @@ class EnsembleGFDL(BaseEstimator):
         if self.reg_alpha is not None and self.reg_alpha < 0.0:
             raise ValueError("Negative reg_alpha. Expected range : None or [0.0, inf).")
 
+        hidden_layer_sizes = np.asarray(self.hidden_layer_sizes)
+        if hidden_layer_sizes.min() < 1:
+            raise ValueError("hidden_layer_sizes must be > 0, "
+                             f"got {hidden_layer_sizes}")
         fn = resolve_activation(self.activation)[1]
         self._activation_fn = fn
         self._N = X.shape[1]
-        hidden_layer_sizes = np.asarray(self.hidden_layer_sizes)
         self._weight_mode = resolve_weight(self.weight_scheme)
 
         self.W_ = []

--- a/src/gfdl/tests/test_model.py
+++ b/src/gfdl/tests/test_model.py
@@ -516,3 +516,15 @@ def test_rtol_ensemble(reg_alpha, rtol, expected_acc, expected_roc):
 
     np.testing.assert_allclose(acc_cur, expected_acc)
     np.testing.assert_allclose(roc_cur, expected_roc, atol=1e-05)
+
+
+@pytest.mark.parametrize("hidden_layer_sizes", [
+    (-1, -1, -1),
+    (0, 1, 1),
+])
+@pytest.mark.parametrize("classifier", [GFDLClassifier, EnsembleGFDLClassifier])
+def test_gh_85_classifiers(hidden_layer_sizes, classifier):
+    X, y = make_classification(random_state=42)
+    clf = classifier(hidden_layer_sizes=hidden_layer_sizes, seed=0)
+    with pytest.raises(ValueError, match="must be > 0"):
+        clf.fit(X, y)

--- a/src/gfdl/tests/test_regression.py
+++ b/src/gfdl/tests/test_regression.py
@@ -140,3 +140,14 @@ def test_regression_boston(reg_alpha, expected):
     # worse, but certainly better than random chance:
     actual = r2_score(y_test, y_pred)
     np.testing.assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("hidden_layer_sizes", [
+    (-1, -1, -1),
+    (0, 1, 1),
+])
+def test_gh_85_regressor(hidden_layer_sizes):
+    X, y = make_regression(random_state=42)
+    model = GFDLRegressor(hidden_layer_sizes=hidden_layer_sizes, seed=0)
+    with pytest.raises(ValueError, match="must be > 0"):
+        model.fit(X, y)


### PR DESCRIPTION
* Fixes gh-85.

* Add classifier and regressor regression tests that fail for the problem scenarios described in the matching issue, and pass with the new source code error handling shims added here.

* In short, this aims to unify our approach to handling neural network widths <= 0 with `sklearn` `MLPClassifier`, to provide more straightforward error feedback to the user. These kind of inputs can show up by accident in hyperopt for example.

* Note that in some cases we were not even erroring out when calling `fit()` on the bad input, which is arguably a bug.