### PR TITLE
MAINT, CI: Specify hash for doc related actions.

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
     # needed for pages deployment from the main or the deployment test branch
     - name: upload pages artifacts
-      uses: actions/upload-pages-artifact@v5
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 #v5.0.0
       with:
         path: docs/build/html  
 
@@ -56,4 +56,4 @@ jobs:
     environment:
       name: github-pages
     steps:
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 #v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,6 @@ jobs:
         cd docs && make html SPHINXOPTS="-W --keep-going"
         
     - name: upload PR artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         path: docs/build/html


### PR DESCRIPTION
Related to issue #80 , added the hashes for the github actions related to artifact uploads and deployment. 