### PR TITLE
MAINT: remove spurious comment

### DIFF
--- a/src/gfdl/tests/test_model.py
+++ b/src/gfdl/tests/test_model.py
@@ -1,5 +1,3 @@
-# tests/test_model.py
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose


### PR DESCRIPTION
* There isn't much point in naming the path to a module at the top of a Python source file, and it may become a maintenance burden in the future if we reorganize things, so just remove the last remaining case in our source where this happens.