### PR TITLE
DOC: update GFDL 0.2.0 release notes

### DIFF
--- a/docs/source/release/0.2.0-notes.rst
+++ b/docs/source/release/0.2.0-notes.rst
@@ -6,7 +6,7 @@ GFDL 0.2.0 Release Notes
 
 .. contents::
 
-Gradient free deep learning (GFDL) 0.2.0 is the culmination of X
+Gradient free deep learning (GFDL) 0.2.0 is the culmination of 3
 months of hard work. Our development attention will now shift to
 bug-fix releases on the 0.2.x branch, and on adding new features
 on the main branch.
@@ -18,6 +18,10 @@ This release requires Python 3.12-3.14.
 Highlights of this release
 **************************
 
+* We now have public user facing html documentation:
+  https://lanl.github.io/GFDL/
+* All estimators now support the new ``partial_fit`` method, which may
+  be useful for handling design matrices that do not fit into system memory.
 
 
 ************
@@ -44,16 +48,47 @@ Other changes
 *******
 Authors
 *******
+* Name (commits)
+* Navamita Ray (60)
+* Tyler Reddy (26)
+* Emma Viani (2)
 
+    A total of 3 people contributed to this release.
+    People with a "+" by their names contributed a patch for the first time.
+    This list of names is automatically generated, and may not be fully complete.
 
 
 ************************
 Issues closed for 0.2.0
 ************************
 
+* `#32 <https://github.com/lanl/GFDL/issues/32>`__: DOC, CI: only need to build/lint docs once in the CI
+* `#33 <https://github.com/lanl/GFDL/issues/33>`__: DOC, CI, MAINT: deploying docs
+* `#59 <https://github.com/lanl/GFDL/issues/59>`__: DOC, MAINT: PyPI landing page missing description
+* `#62 <https://github.com/lanl/GFDL/issues/62>`__: MAINT, CI: setup dependabot
+* `#65 <https://github.com/lanl/GFDL/issues/65>`__: DOC, MAINT: link back to deployed docs from PyPI page
+* `#80 <https://github.com/lanl/GFDL/issues/80>`__: MAINT, CI: pin some dependencies to specific hashes
+* `#85 <https://github.com/lanl/GFDL/issues/85>`__: MAINT: better error messages/design for layer widths <= 0 ?
 
 ************************
 Pull requests for 0.2.0
 ************************
 
-
+* `#53 <https://github.com/lanl/GFDL/pull/53>`__: CI, DOC: Separate docs build from CI test jobs, deployment
+* `#55 <https://github.com/lanl/GFDL/pull/55>`__: REL: set version to 0.2.0
+* `#58 <https://github.com/lanl/GFDL/pull/58>`__: MAINT: EnsembleGFDL--inherit from base
+* `#60 <https://github.com/lanl/GFDL/pull/60>`__: MAINT, CI: bump ruff
+* `#61 <https://github.com/lanl/GFDL/pull/61>`__: DOC, MAINT: description for PyPI page
+* `#66 <https://github.com/lanl/GFDL/pull/66>`__: DOC, MAINT: add PyPI doc link
+* `#73 <https://github.com/lanl/GFDL/pull/73>`__: MAINT, CI: draft dependabot configuration
+* `#76 <https://github.com/lanl/GFDL/pull/76>`__: MAINT: Bump actions/upload-pages-artifact from 3 to 4
+* `#77 <https://github.com/lanl/GFDL/pull/77>`__: MAINT: Bump actions/deploy-pages from 4 to 5
+* `#78 <https://github.com/lanl/GFDL/pull/78>`__: MAINT: Bump actions/upload-artifact from 4 to 7
+* `#79 <https://github.com/lanl/GFDL/pull/79>`__: MAINT: Bump actions/setup-python from 5 to 6
+* `#81 <https://github.com/lanl/GFDL/pull/81>`__: MAINT: Bump actions/checkout from 4 to 6
+* `#83 <https://github.com/lanl/GFDL/pull/83>`__: MAINT, CI: pin ``actions/setup-python``
+* `#86 <https://github.com/lanl/GFDL/pull/86>`__: MAINT: Bump actions/upload-pages-artifact from 4 to 5
+* `#87 <https://github.com/lanl/GFDL/pull/87>`__: MAINT: errors for widths <= 0
+* `#88 <https://github.com/lanl/GFDL/pull/88>`__: MAINT: actions/checkout hash pins
+* `#89 <https://github.com/lanl/GFDL/pull/89>`__: MAINT, CI: Specify hash for doc related actions.
+* `#95 <https://github.com/lanl/GFDL/pull/95>`__: MAINT: remove spurious comment

--- a/docs/source/release/0.2.0-notes.rst
+++ b/docs/source/release/0.2.0-notes.rst
@@ -2,8 +2,6 @@
 GFDL 0.2.0 Release Notes
 ==========================
 
-.. note:: GFDL 0.2.0 is not released yet!
-
 .. contents::
 
 Gradient free deep learning (GFDL) 0.2.0 is the culmination of 3
@@ -31,6 +29,8 @@ New features
 
 ``gfdl.model`` improvements
 ============================
+- All estimators now support the new ``partial_fit`` method, which may
+  be useful for handling design matrices that do not fit into system memory.
 
 *******************
 Deprecated features
@@ -43,6 +43,8 @@ Backwards incompatible changes
 *************
 Other changes
 *************
+- We now have public user facing html documentation:
+  https://lanl.github.io/GFDL/
 
 
 *******
@@ -50,8 +52,8 @@ Authors
 *******
 * Name (commits)
 * Navamita Ray (60)
-* Tyler Reddy (26)
-* Emma Viani (2)
+* Tyler Reddy (36)
+* Emma Viani (81)
 
     A total of 3 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
@@ -69,11 +71,13 @@ Issues closed for 0.2.0
 * `#65 <https://github.com/lanl/GFDL/issues/65>`__: DOC, MAINT: link back to deployed docs from PyPI page
 * `#80 <https://github.com/lanl/GFDL/issues/80>`__: MAINT, CI: pin some dependencies to specific hashes
 * `#85 <https://github.com/lanl/GFDL/issues/85>`__: MAINT: better error messages/design for layer widths <= 0 ?
+* `#96 <https://github.com/lanl/GFDL/issues/96>`__: DOC: method links do not work in the documentation
 
 ************************
 Pull requests for 0.2.0
 ************************
 
+* `#47 <https://github.com/lanl/GFDL/pull/47>`__: ENH: partial fit implementation with tests
 * `#53 <https://github.com/lanl/GFDL/pull/53>`__: CI, DOC: Separate docs build from CI test jobs, deployment
 * `#55 <https://github.com/lanl/GFDL/pull/55>`__: REL: set version to 0.2.0
 * `#58 <https://github.com/lanl/GFDL/pull/58>`__: MAINT: EnsembleGFDL--inherit from base
@@ -92,3 +96,4 @@ Pull requests for 0.2.0
 * `#88 <https://github.com/lanl/GFDL/pull/88>`__: MAINT: actions/checkout hash pins
 * `#89 <https://github.com/lanl/GFDL/pull/89>`__: MAINT, CI: Specify hash for doc related actions.
 * `#95 <https://github.com/lanl/GFDL/pull/95>`__: MAINT: remove spurious comment
+* `#100 <https://github.com/lanl/GFDL/pull/100>`__: DOC: custom template to link methods in documentation


### PR DESCRIPTION
* Update the `gfdl` `0.2.0` release notes, as we get closer to the release process.

Do not merge this until we are ready to start the release.