### PR TITLE
MAINT: version pins/prep for 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=69, <82.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,10 +25,10 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dependencies = ["numpy>=2.0.0",
-                "scikit-learn>=1.5.0",
-                "scipy>=1.13.0",
-                "packaging>=24.0"]
+dependencies = ["numpy>=2.0.0,<2.7",
+                "scikit-learn>=1.5.0,<1.11",
+                "scipy>=1.13.0,<1.20",
+                "packaging>=24.0,<27.0"]
 
 [project.urls]
 source = "https://github.com/lanl/GFDL"


### PR DESCRIPTION
* Enforce some upper version bounds on dependencies to prevent our `0.2.0` release
from breaking longer term as new versions of our deps get released.

* The rough rule in the scientific Python ecosystem is that you can safely support the next two feature releases of a project beyond what is already released because of the deprecation policies typically used. For some of our deps that I'm less familiar with,
I imposed a tighter upper bound to be safer.