### PR TITLE
MAINT: simplify deps, remove matplotlib

### DIFF
--- a/.github/constraints/deps.txt
+++ b/.github/constraints/deps.txt
@@ -2,7 +2,6 @@ numpy>=2.0.0
 scipy>=1.13.0
 scikit-learn>=1.5.0
 packaging>=24.0
-matplotlib>=3.7.5
 numpydoc
 sphinx_copybutton
 sphinx_design

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install build pytest pytest-cov matplotlib
+        python -m pip install build pytest pytest-cov
     - name: Generate wheel and sdist
       run: |
         python -m build

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,6 @@ extensions = [
     'numpydoc',
     'sphinx_copybutton',
     'sphinx_design',
-    'matplotlib.sphinxext.plot_directive',
     "sphinx.ext.linkcode",
 ]
 


### PR DESCRIPTION
* Related to a discussion with Emma at: https://github.com/lanl/GFDL/pull/103#discussion_r3228233708

* It appears that we may no longer need to depend on `matplotlib`, so let's see if the CI passes when we remove its installation everywhere. Generally, removing deps is a simplification win.

* ~`git grep -E -i "matplotlib"` does show a remaining `sphinx` extension in our doc build config, but I think that's "ok" to leave alone--if we ever need to add `matplotlib` plots to our documentation we can revisit the dependency situation.~