### PR TITLE
TST: enforce proper `sklearn` `__init__` for classifiers

### DIFF
--- a/src/gfdl/tests/test_model.py
+++ b/src/gfdl/tests/test_model.py
@@ -440,6 +440,27 @@ def test_sklearn_api_conformance(estimator, check):
     check(estimator)
 
 
+@pytest.mark.parametrize("estimator", [
+    GFDLClassifier, EnsembleGFDLClassifier
+])
+def test_preserve_class_inputs(estimator):
+    # see: gh-111
+    clf = estimator(seed=0)
+    actual = clf.get_params()
+    expected = {"activation": "identity",
+                "hidden_layer_sizes": (100,),
+                "reg_alpha": None,
+                "rtol": None,
+                "seed": 0,
+                "voting": "soft",
+                "weight_scheme": "uniform",
+                "direct_links": True}
+    for k, v in actual.items():
+        if k in expected:
+            assert v == expected[k]
+            assert isinstance(v, type(expected[k]))
+
+
 @pytest.mark.parametrize("reg_alpha, rtol, expected_acc, expected_roc", [
     (0.1, 1e-15, 0.9083333333333333, 0.9893414717354735),
     (None, 1e-15, 0.2222222222222222, 0.5518850599798965),


### PR DESCRIPTION
* Related to gh-111, but only aims to address a subset of it, and only for classifiers for now. If others want to help deal with regressors and other parts of the issue that is welcome.

* The regression test added here should now cause a failure when the violation of `sklearn` `__init__` conventions from https://github.com/lanl/GFDL/pull/70#discussion_r3321068005 is introduced into the source code.

* Although I did not use AI in the preparation of this branch, the original review comment above is from the greptile AI reviewer.