### PR TITLE
TST: enforce proper `sklearn` `__init__` -- regressors

### DIFF
--- a/src/gfdl/tests/test_regression.py
+++ b/src/gfdl/tests/test_regression.py
@@ -241,3 +241,19 @@ def test_gh_85_regressor(hidden_layer_sizes):
     model = GFDLRegressor(hidden_layer_sizes=hidden_layer_sizes, seed=0)
     with pytest.raises(ValueError, match="must be > 0"):
         model.fit(X, y)
+
+
+def test_preserve_class_inputs():
+    # see: gh-111
+    model = GFDLRegressor(seed=0)
+    actual = model.get_params()
+    expected = {"activation": "identity",
+                "direct_links": True,
+                "hidden_layer_sizes": (100,),
+                "reg_alpha": None,
+                "rtol": None,
+                "seed": 0,
+                "weight_scheme": "uniform"}
+    for k, v in actual.items():
+        assert v == expected[k]
+        assert isinstance(v, type(expected[k]))


### PR DESCRIPTION
* Related to gh-111, but only aims to address a subset of it. This is the regression equivalent to the classifier-based testing added in gh-112.

* Similar to that other PR, the regression test added here also causes a failure when introducing the API violation from https://github.com/lanl/GFDL/pull/70#discussion_r3321068005.

* I did not use AI in the prepartion of this PR, though note that the original review comment that triggered all of this work was from the greptile AI reviewer on GitHub in gh-70.