### PR TITLE
WIP, ENH: exact solve with array backends

### DIFF
--- a/.github/constraints/deps.txt
+++ b/.github/constraints/deps.txt
@@ -1,3 +1,4 @@
+array-api-compat
 numpy>=2.0.0
 scipy>=1.13.0
 scikit-learn>=1.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 dependencies = ["numpy>=2.0.0",
                 "scikit-learn>=1.5.0",
                 "scipy>=1.13.0",
-                "packaging>=24.0"]
+                "packaging>=24.0",
+                "array-api-compat"]
 
 [project.urls]
 source = "https://github.com/lanl/GFDL"

--- a/src/gfdl/model.py
+++ b/src/gfdl/model.py
@@ -2,6 +2,7 @@
 Estimators for gradient free deep learning.
 """
 
+import array_api_compat
 import numpy as np
 import scipy
 from scipy.special import logsumexp
@@ -18,7 +19,6 @@ from sklearn.utils import column_or_1d
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.multiclass import check_classification_targets, unique_labels
 from sklearn.utils.validation import check_is_fitted, validate_data
-import array_api_compat
 
 from gfdl.activations import resolve_activation
 from gfdl.weights import resolve_weight
@@ -89,6 +89,8 @@ class GFDL(BaseEstimator):
         Hs = []
         H_prev = X
         for w, b in zip(self.W_, self.b_, strict=False):
+            w = xp.asarray(w, device=H_prev.device)
+            b = xp.asarray(b, device=H_prev.device)
             Z = H_prev @ w.T + b  # (n_samples, n_hidden)
             H_prev = self._activation_fn(Z)
             Hs.append(H_prev)
@@ -413,6 +415,7 @@ class GFDLClassifier(ClassifierMixin, GFDL):
           Fitted estimator.
         """
         xp = array_api_compat.array_namespace(X, y)
+        y_device = y.device
         # shape: (n_samples, n_features)
         X, Y = validate_data(self, X, y)
         self.classes_ = unique_labels(Y)
@@ -421,8 +424,9 @@ class GFDLClassifier(ClassifierMixin, GFDL):
         # (this is necessary for everything beyond binary classification)
         self.enc_ = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
         # shape: (n_samples, n_classes-1)
-        Y = self.enc_.fit_transform(np.from_dlpack(Y).reshape(-1, 1))
-        Y = xp.asarray(Y)
+        Y = self.enc_.fit_transform(np.from_dlpack(xp.asarray(Y,
+                                    device="cpu")).reshape(-1, 1))
+        Y = xp.asarray(Y, device=y_device)
 
         # call base fit method
         super().fit(X, Y)

--- a/src/gfdl/model.py
+++ b/src/gfdl/model.py
@@ -18,6 +18,7 @@ from sklearn.utils import column_or_1d
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.multiclass import check_classification_targets, unique_labels
 from sklearn.utils.validation import check_is_fitted, validate_data
+import array_api_compat
 
 from gfdl.activations import resolve_activation
 from gfdl.weights import resolve_weight
@@ -47,9 +48,10 @@ class GFDL(BaseEstimator):
         # Assumption : X, Y have been pre-processed.
         # X shape: (n_samples, n_features)
         # Y shape: (n_samples, n_classes-1)
+        xp = array_api_compat.array_namespace(X, Y)
         if self.reg_alpha is not None and self.reg_alpha < 0.0:
             raise ValueError("Negative reg_alpha. Expected range : None or [0.0, inf).")
-        hidden_layer_sizes = np.asarray(self.hidden_layer_sizes)
+        hidden_layer_sizes = xp.asarray(self.hidden_layer_sizes)
         if hidden_layer_sizes.min() < 1:
             raise ValueError("hidden_layer_sizes must be > 0, "
                              f"got {hidden_layer_sizes}")
@@ -95,7 +97,7 @@ class GFDL(BaseEstimator):
         # or (n_samples, sum_hidden)
         if self.direct_links:
             Hs.append(X)
-        D = np.hstack(Hs)
+        D = xp.concat(Hs, axis=1)
 
         # beta shape: (sum_hidden+n_features, n_classes-1)
         # or (sum_hidden, n_classes-1)
@@ -103,7 +105,7 @@ class GFDL(BaseEstimator):
         # If reg_alpha is None, use direct solve using
         # MoorePenrose Pseudo-Inverse, otherwise use ridge regularized form.
         if self.reg_alpha is None:
-            self.coeff_ = np.linalg.pinv(D, rtol=self.rtol) @ Y
+            self.coeff_ = xp.linalg.pinv(D, rtol=self.rtol) @ Y
         else:
             ridge = Ridge(alpha=self.reg_alpha, fit_intercept=False)
             ridge.fit(D, Y)
@@ -410,6 +412,7 @@ class GFDLClassifier(ClassifierMixin, GFDL):
         object
           Fitted estimator.
         """
+        xp = array_api_compat.array_namespace(X, y)
         # shape: (n_samples, n_features)
         X, Y = validate_data(self, X, y)
         self.classes_ = unique_labels(Y)
@@ -418,7 +421,8 @@ class GFDLClassifier(ClassifierMixin, GFDL):
         # (this is necessary for everything beyond binary classification)
         self.enc_ = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
         # shape: (n_samples, n_classes-1)
-        Y = self.enc_.fit_transform(Y.reshape(-1, 1))
+        Y = self.enc_.fit_transform(np.from_dlpack(Y).reshape(-1, 1))
+        Y = xp.asarray(Y)
 
         # call base fit method
         super().fit(X, Y)


### PR DESCRIPTION
* Related to gh-68, but for the opposite case of the exact solve.

* This is a (very) early draft/prototype of supporting the Python array API standard (https://data-apis.org/array-api/latest/) for `GFDLClassifier` when the exact solve is used. Some of the sklearn API conformance tests will currently fail, but all numerical correctness tests with the NumPy backend should continue to pass.

* The basic idea is to take an early peek at our potential for speedups when using JIT compiled/GPU backend array types, since i.e., hyperopt can be slow on CPU alone, and also because we'd just like to deliver the most performant estimators that we can, which also helps us conduct numerical experiments for the mathematicians with faster turnaround times.

Using a benchmark script similar to the one below the fold, here are some sample results showing some promising-looking speedups on this branch vs. plain NumPy. I'd probably prefer to hand this effort off to someone else, but does seem worth pursuing.

<details>

```python
import time
import argparse


from tqdm import tqdm
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import numpy as np
from sklearn.datasets import make_classification
from sklearn import config_context
from sklearn.utils.validation import check_is_fitted
import jax.numpy as jnp
import torch


from gfdl.model import GFDLClassifier


def perform_benchmarks():
    results = {}

    sample_sizes = [1_000, 2_000, 3_000, 10_000]
    fig, ax = plt.subplots()
    for backend in tqdm(["numpy", "jax", "torch"], desc="backends"):
        average_times = []
        std_times = []
        for n_samples in tqdm(sample_sizes, desc="sample sizes"):
            X, y = make_classification(n_samples=n_samples, n_features=2000, random_state=42)

            if backend == "jax":
                X = jnp.array(X)
                y = jnp.array(y)
            elif backend == "torch":
                X = torch.asarray(X)
                y = torch.asarray(y)

            trial_times = []
            for num_trials in tqdm(range(3), desc="replicate"):
                with config_context(array_api_dispatch=True):
                    clf = GFDLClassifier()
                    start = time.perf_counter()
                    clf.fit(X, y)
                    # we check that the estimator is actually fitted, as a precaution
                    # against backends that may not be sync'd/blocking
                    check_is_fitted(clf)
                    end = time.perf_counter()
                    trial_times.append(end - start)
            average_times.append(np.mean(trial_times))
            std_times.append(np.std(trial_times))
        ax.errorbar(sample_sizes,
                    average_times,
                    yerr=std_times,
                    fmt="o",
                    linestyle="-",
                    capsize=5,
                    label=backend)
    ax.set_ylabel("Average Time (s)")
    ax.set_xlabel("# Records")
    ax.legend()
    ax.set_title("Array API support for GFDLClassifier with exact solve")
    fig.savefig("bench.png", dpi=300)


if __name__ == "__main__":
    perform_benchmarks()
```

</details>

On M3 Max laptop (using CPU):

<img width="1920" height="1440" alt="image" src="https://github.com/user-attachments/assets/63724f20-e6d0-4677-9d1e-53477acabe90" />

On an x86_64 Linux box (also using i9-13900K CPU only for now):

<img width="1920" height="1440" alt="image" src="https://github.com/user-attachments/assets/da0d4e45-aeb4-4eaf-9ef0-5438259c96ff" />

initial TODO:

- [ ] add more mature array API support, including for GPU/devices (currently fails on this branch when I try to use a GPU backend for `torch`)
- [ ] add proper testing for array API support (see i.e., `array-api-strict` and the array API testing harnesses in `sklearn` and SciPy, etc.)
- [ ] sort out how to get our regular `sklearn` conformance tests passing
- [ ] wait for SciPy `2.0.0` release in early 2027 to turn this on by default? (but perhaps allow it behind a flag until then?) -- see: https://discuss.scientific-python.org/t/making-array-types-support-public-scipy-2-0/2355
- [ ] check inference timings, the timings above are just for `fit()`

AI usage: I did not use AI to write the source code of this PR